### PR TITLE
Support for custom CSS and display length of the comment in sonata list

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -14,6 +14,11 @@ use Sonata\AdminBundle\Show\ShowMapper;
 class CommentAdmin extends AbstractAdmin
 {
     /**
+     * Default value for commentsDisplayMaxLength.
+     */
+    const DEFAULT_COMMENT_DISPLAY_MAX_LENGTH = 20;
+
+    /**
      * Default datagrid values.
      * Assures that comments are sorted by dateCreated descending by default.
      *
@@ -29,6 +34,13 @@ class CommentAdmin extends AbstractAdmin
      * @var string
      */
     protected $translationDomain = 'MICommentsBundle';
+
+    /**
+     * Max length of the comment in the list view.
+     *
+     * @var int
+     */
+    private $commentDisplayMaxLength = self::DEFAULT_COMMENT_DISPLAY_MAX_LENGTH;
 
     /**
      * {@inheritdoc}
@@ -62,6 +74,7 @@ class CommentAdmin extends AbstractAdmin
         $listMapper->addIdentifier('entityTitle');
         $listMapper->addIdentifier('comment', null, [
             'template' => '@MIComments/Sonata/list_truncated.html.twig',
+            'length' => $this->getCommentDisplayMaxLength(),
         ]);
         $listMapper->addIdentifier('dateCreated');
         $listMapper->addIdentifier('status', null, [
@@ -121,5 +134,21 @@ class CommentAdmin extends AbstractAdmin
         $collection->remove('delete');
         $collection->add('publish', $this->getRouterIdParameter().'/publish');
         $collection->add('reject', $this->getRouterIdParameter().'/reject');
+    }
+
+    /**
+     * @return int
+     */
+    public function getCommentDisplayMaxLength(): int
+    {
+        return $this->commentDisplayMaxLength;
+    }
+
+    /**
+     * @param int $commentDisplayMaxLength
+     */
+    public function setCommentDisplayMaxLength(int $commentDisplayMaxLength): void
+    {
+        $this->commentDisplayMaxLength = $commentDisplayMaxLength;
     }
 }

--- a/DependencyInjection/Compiler/TwigGlobalsPass.php
+++ b/DependencyInjection/Compiler/TwigGlobalsPass.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MovingImage\Bundle\MICommentsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TwigGlobalsPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $twig = $container->getDefinition('twig');
+        $css = $container->getParameter('mi_comments.css');
+        $twig->addMethodCall('addGlobal', ['mi_comments_css', $css]);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MovingImage\Bundle\MICommentsBundle\DependencyInjection;
 
+use MovingImage\Bundle\MICommentsBundle\Admin\CommentAdmin;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -24,6 +25,8 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('auto_publish')->defaultValue(false)->end()
+                ->scalarNode('css')->defaultValue(null)->end()
+                ->scalarNode('display_max_length')->defaultValue(CommentAdmin::DEFAULT_COMMENT_DISPLAY_MAX_LENGTH)->end()
             ->end()
         ;
 

--- a/MICommentsBundle.php
+++ b/MICommentsBundle.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 namespace MovingImage\Bundle\MICommentsBundle;
 
+use MovingImage\Bundle\MICommentsBundle\DependencyInjection\Compiler\TwigGlobalsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class MICommentsBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new TwigGlobalsPass());
+    }
 }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You may choose a different prefix if required.
 ```
 mi_comments:
    auto_publish: true //optional, by default is false
+   css: /path/to/css/file //optional
+   display_max_length: 100 //optional
 ```
 
 ### Configure doctrine migrations bundle in config.yml (optional)
@@ -118,9 +120,11 @@ You may choose a different prefix if required.
 
 ## Configuration parameters
 
-Parameter       | Type      | Default   | Required  | Description
-----------------|-----------|-----------|-----------|------------
-auto_publish    | boolean   | false     | no        | If true, comments are automatically published
+Parameter           | Type      | Default   | Required  | Description
+--------------------|-----------|-----------|-----------|------------
+auto_publish        | boolean   | false     | no        | If true, comments are automatically published.
+css                 | string    | null      | no        | Path to CSS file. If provided, will be included in the sonata layout.
+display_max_length  | int       | 20        | no        | Maximum length of the comment displayed in the sonata list.
 
 ## Usage
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -31,6 +31,7 @@ services:
             - MovingImage\Bundle\MICommentsBundle\Controller\SonataCommentsController
         calls:
             - [setTemplate, ['layout', '@@MIComments/Sonata/layout.html.twig']]
+            - [setCommentDisplayMaxLength, ['%mi_comments.display_max_length%']]
         tags:
             - { name: sonata.admin, manager_type: orm, label: Comment, group: Comments }
         public: true

--- a/Resources/views/Sonata/layout.html.twig
+++ b/Resources/views/Sonata/layout.html.twig
@@ -2,11 +2,13 @@
 
 {# Remove sonata header - it's pretty useless when you only have one admin class #}
 {% block sonata_header %}{% endblock sonata_header %}
-
 {# Add custom stylesheets #}
 {% block stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('/bundles/micomments/css/sonata.css') }}">
+    {% if mi_comments_css %}
+        <link rel="stylesheet" href="{{ asset(mi_comments_css) }}">
+    {% endif %}
 {% endblock stylesheets %}
 
 {# Remove sidebar #}

--- a/Resources/views/Sonata/list_truncated.html.twig
+++ b/Resources/views/Sonata/list_truncated.html.twig
@@ -1,6 +1,5 @@
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {%- block field %}
-    {% set length = field_description.options.length ? field_description.options.length : 20 %}
-    {{ value|truncate(length) }}
+    {{ value|truncate(field_description.options.length) }}
 {% endblock %}

--- a/Tests/Controller/SonataCommentsControllerTest.php
+++ b/Tests/Controller/SonataCommentsControllerTest.php
@@ -10,6 +10,7 @@ use MovingImage\Bundle\MICommentsBundle\Entity\Comment;
 use MovingImage\Bundle\MICommentsBundle\Service\CommentsService;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -75,6 +76,8 @@ class SonataCommentsControllerTest extends TestCase
                     return $requestStack;
                 case 'sonata.admin.pool':
                     return $pool;
+                case '.template_registry':
+                    return new TemplateRegistry();
             }
         });
 


### PR DESCRIPTION
Adds the following config options:
`css` - path to css file that will be included in the sonata admin section
`display_max_length` - max length of the comment in the sonata list